### PR TITLE
Add email forwarding endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 [![Review Assignment Due Date](https://classroom.github.com/assets/deadline-readme-button-22041afd0340ce965d47ae6ef1cefeee28c7c493a6346c4f15d667ab976d596c.svg)](https://classroom.github.com/a/4-04QCSZ)
+
+## Environment Variables for Email Forwarding
+
+Set these variables for the server when using the support and forgot password forms:
+
+- `SMTP_HOST` – SMTP server hostname
+- `SMTP_PORT` – SMTP port number
+- `SMTP_USER` – SMTP username
+- `SMTP_PASS` – SMTP password
+- `SUPPORT_FROM` – email address used as the sender
+- `CLIENT_EMAIL` – destination address for forwarded messages
+
+Example `.env` configuration:
+
+```env
+SMTP_HOST=smtp.example.com
+SMTP_PORT=465
+SMTP_USER=user@example.com
+SMTP_PASS=your_password
+SUPPORT_FROM=support@example.com
+CLIENT_EMAIL=client@example.com
+```

--- a/app/app/(auth)/Support/index.tsx
+++ b/app/app/(auth)/Support/index.tsx
@@ -14,7 +14,7 @@ export default function SupportScreen() {
   const [enquiry, setEnquiry] = useState('');
 
   const { theme } = useContext(ThemeContext);
-  const GETFORM_ENDPOINT = 'https://getform.io/f/bpjpjpvb'; 
+  const API_URL = 'http://localhost:3000/api';
 
   const handleSubmit = async () => {
     if (!firstName || !lastName || !email || !contact || !enquiry) {
@@ -33,7 +33,7 @@ export default function SupportScreen() {
     const formBody = new URLSearchParams(data).toString();
 
     try {
-      const response = await fetch(GETFORM_ENDPOINT, {
+      const response = await fetch(`${API_URL}/support`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded',

--- a/app/app/forgotpassword.tsx
+++ b/app/app/forgotpassword.tsx
@@ -14,7 +14,7 @@ export default function ContactFormScreen() {
   const [contact, setContact] = useState('');
   const { theme, isDarkMode } = useContext(ThemeContext);
 
-  const GETFORM_ENDPOINT = 'https://getform.io/f/bpjpjpvb';
+  const API_URL = 'http://localhost:3000/api';
 
   const handleSubmit = async () => {
     if (!firstName || !lastName || !email || !contact) {
@@ -31,7 +31,7 @@ export default function ContactFormScreen() {
     const formBody = new URLSearchParams(data).toString();
 
     try {
-      const response = await fetch(GETFORM_ENDPOINT, {
+      const response = await fetch(`${API_URL}/support/forgot-password`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded',

--- a/cms/server/package.json
+++ b/cms/server/package.json
@@ -22,6 +22,7 @@
     "mongoose": "^8.13.2",
     "multer": "^2.0.0",
     "multer-s3": "^3.0.1",
+    "nodemailer": "^6.9.11",
     "sanitize-html": "^2.17.0",
     "swagger-ui-express": "^5.0.1",
     "tsoa": "^6.6.0"

--- a/cms/server/src/service-layer/controllers/SupportController.ts
+++ b/cms/server/src/service-layer/controllers/SupportController.ts
@@ -1,0 +1,58 @@
+import { Controller, Post, Route, Tags, Body } from "tsoa";
+import nodemailer from "nodemailer";
+
+interface SupportRequest {
+  first_name: string;
+  last_name: string;
+  preferred_email: string;
+  contact_number: string;
+  enquiry_message?: string;
+}
+
+interface BasicRequest {
+  first_name: string;
+  last_name: string;
+  preferred_email: string;
+  contact_number: string;
+}
+
+@Route("support")
+@Tags("Support")
+export class SupportController extends Controller {
+  /** Send email for support form */
+  @Post()
+  public async sendSupport(@Body() body: SupportRequest): Promise<{ success: boolean }> {
+    await sendMail("Support Request", body);
+    return { success: true };
+  }
+
+  /** Send email for forgot password form */
+  @Post("/forgot-password")
+  public async forgotPassword(@Body() body: BasicRequest): Promise<{ success: boolean }> {
+    await sendMail("Forgot Password Request", body);
+    return { success: true };
+  }
+}
+
+async function sendMail(subject: string, body: any) {
+  const transporter = nodemailer.createTransport({
+    host: process.env.SMTP_HOST,
+    port: Number(process.env.SMTP_PORT) || 587,
+    secure: Number(process.env.SMTP_PORT) === 465,
+    auth: {
+      user: process.env.SMTP_USER,
+      pass: process.env.SMTP_PASS,
+    },
+  });
+
+  const message = Object.entries(body)
+    .map(([key, value]) => `${key}: ${value}`)
+    .join("\n");
+
+  await transporter.sendMail({
+    from: process.env.SUPPORT_FROM,
+    to: process.env.CLIENT_EMAIL,
+    subject,
+    text: message,
+  });
+}


### PR DESCRIPTION
## Summary
- add nodemailer dependency and SupportController for email forwarding
- update support and forgot password forms to hit backend instead of Getform
- document SMTP environment variables in README

## Testing
- `npm test` (fails: no tests)
- `npm run build` in `cms/server` *(fails: tsoa not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fb6cece2c8324a378b210ef542ef8